### PR TITLE
bug: fix Dataset init call unknown parameter

### DIFF
--- a/bit_diffusion/bit_diffusion.py
+++ b/bit_diffusion/bit_diffusion.py
@@ -653,7 +653,7 @@ class Trainer(object):
 
         # dataset and dataloader
 
-        self.ds = Dataset(folder, self.image_size, augment_horizontal_flip = augment_horizontal_flip, convert_image_to = pil_img_type)
+        self.ds = Dataset(folder, self.image_size, augment_horizontal_flip = augment_horizontal_flip, pil_img_type = pil_img_type)
         dl = DataLoader(self.ds, batch_size = train_batch_size, shuffle = True, pin_memory = True, num_workers = cpu_count())
 
         dl = self.accelerator.prepare(dl)


### PR DESCRIPTION
The 'convert_image_to' parameter should be the 'pil_img_type'.